### PR TITLE
Fixes and improvements to the MySQL database

### DIFF
--- a/mysql/sampledb/v1/data/name_data.sql
+++ b/mysql/sampledb/v1/data/name_data.sql
@@ -1622,7 +1622,7 @@ Insert into name_data (name_type,name) values ('LAST','Yefri');
 Insert into name_data (name_type,name) values ('LAST','Yeldon');
 Insert into name_data (name_type,name) values ('LAST','Yhonathan');
 Insert into name_data (name_type,name) values ('LAST','Yimi');
-Insert into name_data (name_type,name) values ('LAST','Yoenis')
+Insert into name_data (name_type,name) values ('LAST','Yoenis');
 Insert into name_data (name_type,name) values ('LAST','Yoervis');
 Insert into name_data (name_type,name) values ('LAST','Yohan');
 Insert into name_data (name_type,name) values ('LAST','Yohander');

--- a/mysql/sampledb/v1/schema/create_dms_sample.sql
+++ b/mysql/sampledb/v1/schema/create_dms_sample.sql
@@ -14,4 +14,5 @@
 #  limitations under the License.
 
 
-create database if not exists dms_sample;
+create database if not exists dms_sample
+  character set utf8 collate utf8_unicode_ci;

--- a/mysql/sampledb/v1/schema/name_data.tab
+++ b/mysql/sampledb/v1/schema/name_data.tab
@@ -16,6 +16,6 @@
 
 create table name_data(
  name_type VARCHAR(15) NOT NULL,
- name      VARCHAR(45) NOT NULL CHARACTER SET utf8 COLLATE utf8_bin, # make this column case sensitive because there case sensitive dups in the source data
+ name      VARCHAR(45) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, # make this column case sensitive because there case sensitive dups in the source data
  constraint name_data_pk primary key(name_type, name)
 );

--- a/mysql/sampledb/v1/schema/name_data.tab
+++ b/mysql/sampledb/v1/schema/name_data.tab
@@ -16,6 +16,6 @@
 
 create table name_data(
  name_type VARCHAR(15) NOT NULL,
- name      VARCHAR(45) NOT NULL,
+ name      VARCHAR(45) NOT NULL CHARACTER SET utf8 COLLATE utf8_bin, # make this column case sensitive because there case sensitive dups in the source data
  constraint name_data_pk primary key(name_type, name)
 );


### PR DESCRIPTION
Fixes:
Syntax error in name_data - missing semi-colon
Duplicate key errors on insert in name_data - this is due to data that varies only by case, resolved by making the name column case sensitive.

Improvement:
Set the character set and collation for the dms_sample database so that it uses utf8 and unicode rather than the latin1 swedish MySQL defaults.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.